### PR TITLE
Add session argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip.req import parse_requirements
 
 CONFIG_PATH = '~/'
 
-install_reqs = parse_requirements('requirements.txt')
+install_reqs = parse_requirements('requirements.txt', session=False)
 reqs = [str(ir.req) for ir in install_reqs]
 
 setup(name='sd-bandwidth',


### PR DESCRIPTION
session argument is expected, so the install fails on pip > 1.6